### PR TITLE
Use schematics model's to_native rather than to_primitive

### DIFF
--- a/hyp/adapters/marshmallow.py
+++ b/hyp/adapters/marshmallow.py
@@ -2,5 +2,5 @@ class Adapter(object):
     def __init__(self, serializer_class):
         self.serializer_class = serializer_class
 
-    def to_primitive(self, instance):
+    def __call__(self, instance):
         return self.serializer_class(instance).data

--- a/hyp/adapters/schematics.py
+++ b/hyp/adapters/schematics.py
@@ -2,8 +2,8 @@ class Adapter(object):
     def __init__(self, serializer_class):
         self.model_class = serializer_class
 
-    def to_primitive(self, instance):
-        return self.instance_to_model(instance).to_primitive()
+    def __call__(self, instance):
+        return self.instance_to_model(instance).to_native()
 
     def instance_to_model(self, instance):
         model = self.model_class()

--- a/hyp/responder.py
+++ b/hyp/responder.py
@@ -49,7 +49,7 @@ class Responder(object):
         rv = []
 
         for instance in instances:
-            resource = self.adapter.to_primitive(instance)
+            resource = self.adapter(instance)
 
             if links is not None:
                 resource_links = {}

--- a/tests/test_marshmallow_adapter.py
+++ b/tests/test_marshmallow_adapter.py
@@ -19,16 +19,16 @@ def marshmallow_adapter():
 
 
 def test_object_conversion(marshmallow_adapter):
-    assert marshmallow_adapter.to_primitive(Post())['id'] == 1
+    assert marshmallow_adapter(Post())['id'] == 1
 
 
 def test_dict_conversion(marshmallow_adapter):
-    assert marshmallow_adapter.to_primitive({'id': 1})['id'] == 1
+    assert marshmallow_adapter({'id': 1})['id'] == 1
 
 
 def test_object_none_attribute(marshmallow_adapter):
     post = Post()
     post.id = None
 
-    assert marshmallow_adapter.to_primitive({'id': None})['id'] is None
-    assert marshmallow_adapter.to_primitive(post)['id'] is None
+    assert marshmallow_adapter({'id': None})['id'] is None
+    assert marshmallow_adapter(post)['id'] is None

--- a/tests/test_schematics_adapter.py
+++ b/tests/test_schematics_adapter.py
@@ -20,17 +20,22 @@ def adapter():
 
 
 def test_object_conversion(adapter):
-    assert adapter.to_primitive(Post())['id'] == 1
+    assert adapter(Post())['id'] == 1
 
 
 def test_dict_conversion(adapter):
     adapter = SchematicsAdapter(Simple)
-    assert adapter.to_primitive({'id': 1})['id'] == 1
+    assert adapter({'id': 1})['id'] == 1
+
+
+def test_dict_conversion_to_right_type(adapter):
+    adapter = SchematicsAdapter(Simple)
+    assert adapter({'id': '1'})['id'] == 1
 
 
 def test_object_none_attribute(adapter):
     post = Post()
     post.id = None
 
-    assert adapter.to_primitive({'id': None})['id'] is None
-    assert adapter.to_primitive(post)['id'] is None
+    assert adapter({'id': None})['id'] is None
+    assert adapter(post)['id'] is None


### PR DESCRIPTION
`to_native` does type coercion. This way, the serialized output honours
the type definition specified in the schematics model.
