### PR TITLE
Convenience API making Resonder's easier to use and test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+env
+.idea
+
 *.py[cod]
 
 # C extensions

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ post = {
     ]
 }
 
-json = PostResponder().respond(post, linked={'comments': post['comments']})
+json = PostResponder.dumps(post, linked={'comments': post['comments']})
 
 ```
 
@@ -110,4 +110,22 @@ The `json` variable will now contain some freshly squeezed JSON ready for sendin
         }
     }
 }
+```
+
+If you'd like to get have dict returned instead of json, 
+for example if you want to use flask's [jsonify](http://flask.pocoo.org/docs/api/#flask.json.jsonify), 
+then you can use the `build` method instead like so:
+ 
+```python
+post = {
+    'id': 1,
+    'title': 'My post',
+    'comments': [
+        {'id': 1, 'content': 'A comment'},
+        {'id': 2, 'content': 'Another comment'},
+    ]
+}
+
+response = PostResponder.build(post, linked={'comments': post['comments']})
+json = flask.jsonify(response)
 ```

--- a/hyp/responder.py
+++ b/hyp/responder.py
@@ -60,7 +60,22 @@ class Responder(object):
                 resource_links[link] = self.pick(related, 'id')
         return resource_links
 
-    def respond(self, instances, meta=None, links=None, linked=None):
+    @classmethod
+    def build(cls, *args, **kwargs):
+
+        return cls().get(*args, **kwargs)
+
+    @classmethod
+    def dumps(cls, *args, **kwargs):
+
+        return cls().respond(*args, **kwargs)
+
+    def respond(self, *args, **kwargs):
+        document = self.get(*args, **kwargs)
+
+        return json.dumps(document)
+
+    def get(self, instances, meta=None, links=None, linked=None):
         if not isinstance(instances, list):
             instances = [instances]
 
@@ -77,7 +92,7 @@ class Responder(object):
             document['linked'] = self.build_linked(linked)
         document[self.root] = self.build_resources(instances, links)
 
-        return json.dumps(document)
+        return document
 
     def pluralized_type(self):
         return pluralize(self.TYPE)

--- a/tests/test_linked.py
+++ b/tests/test_linked.py
@@ -1,5 +1,3 @@
-import json
-
 from fixtures import PostResponder
 
 
@@ -10,9 +8,9 @@ def test_linked():
     ]
     post = {'id': 1, 'title': 'My title', 'comments': comments}
 
-    data = PostResponder().respond(post, linked={'comments': comments})
+    data = PostResponder.build(post, linked={'comments': comments})
 
-    assert json.loads(data) == {
+    assert data == {
         'posts': [
             {
                 'id': 1,

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,5 +1,3 @@
-import json
-
 from hyp.responder import Responder
 from fixtures import PostResponder, PostSerializer, CommentResponder
 
@@ -11,9 +9,9 @@ def test_one_to_many():
     ]
     post = {'id': 1, 'title': 'My title', 'comments': comments}
 
-    data = PostResponder().respond(post, links=['comments'])
+    data = PostResponder.build(post, links=['comments'])
 
-    assert json.loads(data) == {
+    assert data == {
         'posts': [
             {
                 'id': 1,
@@ -36,9 +34,9 @@ def test_one_to_one():
     author = {'id': 1}
     post = {'id': 1, 'title': 'My title', 'author': author}
 
-    data = PostResponder().respond(post, links=['author'])
+    data = PostResponder.build(post, links=['author'])
 
-    assert json.loads(data) == {
+    assert data == {
         'posts': [
             {
                 'id': 1,
@@ -71,9 +69,9 @@ def test_without_href():
     ]
     post = {'id': 1, 'title': 'My title', 'comments': comments}
 
-    data = MyPostResponder().respond(post, links=['comments'])
+    data = MyPostResponder.build(post, links=['comments'])
 
-    assert json.loads(data) == {
+    assert data == {
         'posts': [
             {
                 'id': 1,

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -1,21 +1,20 @@
 import json
-
 from fixtures import PostResponder
 
 
 def test_single_object():
-    data = PostResponder().respond({'id': 1, 'title': 'My title'})
+    data = PostResponder.build({'id': 1, 'title': 'My title'})
 
-    assert json.loads(data) == {'posts': [{'id': 1, 'title': 'My title'}]}
+    assert data == {'posts': [{'id': 1, 'title': 'My title'}]}
 
 
 def test_multiple():
-    data = PostResponder().respond([
+    data = PostResponder.build([
         {'id': 1, 'title': 'A title'},
         {'id': 2, 'title': 'Another title'},
     ])
 
-    assert json.loads(data) == {
+    assert data == {
         'posts': [
             {'id': 1, 'title': 'A title'},
             {'id': 2, 'title': 'Another title'},
@@ -24,9 +23,21 @@ def test_multiple():
 
 
 def test_meta():
-    data = PostResponder().respond(
+    data = PostResponder.build(
         {'id': 1, 'title': 'Yeah'},
         meta={'key': 'value'},
     )
 
-    assert json.loads(data)['meta']['key'] == 'value'
+    assert data['meta']['key'] == 'value'
+
+
+def test_dumps():
+    data = PostResponder.dumps([
+        {'id': 1, 'title': 'A title'}
+    ])
+
+    assert json.loads(data) == {
+        'posts': [
+            {'id': 1, 'title': 'A title'}
+        ]
+    }


### PR DESCRIPTION
Updates Responder to have `build` and `dumps` method.

``` python
PostResponder.build(posts) # returns a dictionary
PostResponder.dumps(posts) # returns a json string
```

This approach is popular in Ruby and creates a nicer API when instantiating the Responder is not desirable. For example, check out `Faraday.get` in this project: https://github.com/lostisland/faraday

This also makes testing easier as users of this api would only have to stub out this method call instead of creating a stub, stubbing **init**, then finally stubbing the method call.

You can still use the Responder the old way of course:

``` python
PostResponder().respond(posts) # returns json
PostResponder().get(posts) # returns dictionary
```
