### PR TITLE
Update to marshmallow 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ Tutorial
 First let's define some serializers for your models:
 
 ```python
-from marshmallow import Serializer, fields
+from marshmallow import Schema, fields
 
 
-class CommentSerializer(Serializer):
+class CommentSchema(Schema):
     id = fields.Integer()
     content = fields.String()
 
 
-class PersonSerializer(Serializer):
+class PersonSchema(Schema):
     id = fields.Integer()
     name = fields.String()
 
 
-class PostSerializer(Serializer):
+class PostSchema(Schema):
     id = fields.Integer()
     title = fields.String()
 ```
@@ -39,17 +39,17 @@ from hyp.responder import Responder
 
 class CommentResponder(Responder):
     TYPE = 'comments'
-    SERIALIZER = CommentSerializer
+    SERIALIZER = CommentSchema
 
 
 class PersonResponder(Responder):
     TYPE = 'people'
-    SERIALIZER = PersonSerializer
+    SERIALIZER = PersonSchema
 
 
 class PostResponder(Responder):
     TYPE = 'posts'
-    SERIALIZER = PostSerializer
+    SERIALIZER = PostSchema
     LINKS = {
         'comments': {
             'responder': CommentResponder,

--- a/hyp/adapters/marshmallow.py
+++ b/hyp/adapters/marshmallow.py
@@ -1,6 +1,8 @@
 class Adapter(object):
     def __init__(self, serializer_class):
-        self.serializer_class = serializer_class
+        self.schema_class = serializer_class
+        self.schema = self.schema_class()
 
     def __call__(self, instance):
-        return self.serializer_class(instance).data
+        result = self.schema.dump(instance)
+        return result.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 schematics==0.9-4
-marshmallow==0.5.2
+marshmallow>=1.0.0-a


### PR DESCRIPTION
- Update adapter to use `Schema#dump`
- Update minimum version requirement for marshmallow. (NOTE: Best to specify _minimum_ version requirements for this library rather than pin to specific version. This prevents version conflicts with other libraries).
